### PR TITLE
create separate entry for argtypes in react, so portable stories aren't bloated by the default preview entry containing argtypes enhancement

### DIFF
--- a/code/renderers/react/package.json
+++ b/code/renderers/react/package.json
@@ -37,6 +37,7 @@
     },
     "./preset": "./preset.js",
     "./dist/entry-preview.mjs": "./dist/entry-preview.mjs",
+    "./dist/entry-preview-argtypes.mjs": "./dist/entry-preview-argtypes.mjs",
     "./dist/entry-preview-docs.mjs": "./dist/entry-preview-docs.mjs",
     "./dist/entry-preview-rsc.mjs": "./dist/entry-preview-rsc.mjs",
     "./package.json": "./package.json"
@@ -117,6 +118,7 @@
       "./src/preset.ts",
       "./src/preview.tsx",
       "./src/entry-preview.tsx",
+      "./src/entry-preview-argtypes.ts",
       "./src/entry-preview-docs.ts",
       "./src/entry-preview-rsc.tsx",
       "./src/playwright.ts"

--- a/code/renderers/react/src/entry-preview-argtypes.ts
+++ b/code/renderers/react/src/entry-preview-argtypes.ts
@@ -1,0 +1,19 @@
+import { enhanceArgTypes, extractComponentDescription } from 'storybook/internal/docs-tools';
+import type { ArgTypesEnhancer } from 'storybook/internal/types';
+
+import { extractArgTypes } from './extractArgTypes';
+import type { ReactRenderer } from './public-types';
+
+export { render } from './render';
+export { renderToCanvas } from './renderToCanvas';
+export { mount } from './mount';
+export { applyDecorators } from './applyDecorators';
+
+export const parameters = {
+  docs: {
+    extractArgTypes,
+    extractComponentDescription,
+  },
+};
+
+export const argTypesEnhancers: ArgTypesEnhancer<ReactRenderer>[] = [enhanceArgTypes];

--- a/code/renderers/react/src/entry-preview-docs.ts
+++ b/code/renderers/react/src/entry-preview-docs.ts
@@ -6,3 +6,9 @@ import type { ReactRenderer } from './types';
 export const decorators: DecoratorFunction<ReactRenderer>[] = [jsxDecorator];
 
 export { applyDecorators } from './docs/applyDecorators';
+
+export const parameters = {
+  docs: {
+    story: { inline: true },
+  },
+};

--- a/code/renderers/react/src/entry-preview.tsx
+++ b/code/renderers/react/src/entry-preview.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 
-import { enhanceArgTypes, extractComponentDescription } from 'storybook/internal/docs-tools';
-import type { ArgTypesEnhancer } from 'storybook/internal/types';
-
 import semver from 'semver';
 
 import { getAct, getReactActEnvironment, setReactActEnvironment } from './act-compat';
-import { extractArgTypes } from './extractArgTypes';
-import type { Decorator, ReactRenderer } from './public-types';
+import type { Decorator } from './public-types';
 
 export { render } from './render';
 export { renderToCanvas } from './renderToCanvas';
@@ -30,16 +26,10 @@ export const decorators: Decorator[] = [
   },
 ];
 
+console.log('entry-preview.tsx');
 export const parameters = {
   renderer: 'react',
-  docs: {
-    story: { inline: true },
-    extractArgTypes,
-    extractComponentDescription,
-  },
 };
-
-export const argTypesEnhancers: ArgTypesEnhancer<ReactRenderer>[] = [enhanceArgTypes];
 
 export const beforeAll = async () => {
   try {

--- a/code/renderers/react/src/preset.ts
+++ b/code/renderers/react/src/preset.ts
@@ -17,7 +17,7 @@ export const previewAnnotations: PresetProperty<'previewAnnotations'> = async (
 
   return result
     .concat(input)
-    .concat([join(__dirname, 'entry-preview.mjs')])
+    .concat(join(__dirname, 'entry-preview.mjs'), join(__dirname, 'entry-preview-argtypes.mjs'))
     .concat(docsEnabled ? [join(__dirname, 'entry-preview-docs.mjs')] : [])
     .concat(features?.experimentalRSC ? [join(__dirname, 'entry-preview-rsc.mjs')] : []);
 };

--- a/code/renderers/react/src/preview.tsx
+++ b/code/renderers/react/src/preview.tsx
@@ -14,6 +14,7 @@ import type { RemoveIndexSignature, SetOptional, Simplify, UnionToIntersection }
 
 import { __definePreview as definePreviewBase } from '../../../core/src/shared/preview/csf4';
 import * as reactAnnotations from './entry-preview';
+import * as reactArgTypesAnnotations from './entry-preview-argtypes';
 import * as reactDocsAnnotations from './entry-preview-docs';
 import type { AddMocks } from './public-types';
 import type { ReactRenderer } from './types';
@@ -22,7 +23,12 @@ import type { ReactRenderer } from './types';
 export function __definePreview(preview: ReactPreview['input']) {
   return definePreviewBase({
     ...preview,
-    addons: [reactAnnotations, reactDocsAnnotations, ...(preview.addons ?? [])],
+    addons: [
+      reactAnnotations,
+      reactArgTypesAnnotations,
+      reactDocsAnnotations,
+      ...(preview.addons ?? []),
+    ],
   }) as ReactPreview;
 }
 


### PR DESCRIPTION
Test for commit debe4bd